### PR TITLE
Skip re-installation when any file changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,9 @@ FROM node:14-alpine
 WORKDIR /src
 ENV NODE_ENV production
 
-COPY . .
+COPY package.json package-lock.json ./
 RUN apk add --no-cache git \
   && npm ci --production
+COPY . .
 
 CMD ["npm", "start"]


### PR DESCRIPTION
This makes better use of Docker layer caching by skipping the `RUN` command if none of `package.json` or `package-lock.json` have changed.